### PR TITLE
Adds basic structures of floating-point instructions (types FR and FI)

### DIFF
--- a/src/Instruction/FIInstruction.ts
+++ b/src/Instruction/FIInstruction.ts
@@ -1,0 +1,30 @@
+import Instruction from './Instruction'
+
+import {
+  OP_SHIFT,
+  FMT_SHIFT,
+  FT_SHIFT,
+} from './constants'
+
+/**
+ * FI-Type instruction
+ */
+export default class FIInstruction implements Instruction {
+  public type: string = 'FI'
+  public op: number
+  public fmt: number
+  public ft: number
+  public imm: number
+
+  constructor(op: number, fmt: number, ft: number, imm: number) {
+    this.op = op
+    this.fmt = fmt
+    this.ft = ft
+    this.imm = imm
+  }
+
+  public toInt(): number {
+    const { op, fmt, ft, fs, imm } = this
+    return (op << OP_SHIFT) + (fmt << FMT_SHIFT) + (ft << FT_SHIFT) + imm
+  }
+}

--- a/src/Instruction/FRInstruction.ts
+++ b/src/Instruction/FRInstruction.ts
@@ -1,0 +1,37 @@
+import Instruction from './Instruction'
+
+import {
+  OP_SHIFT,
+  FMT_SHIFT,
+  FT_SHIFT,
+  FS_SHIFT,
+  FD_SHIFT,
+  FUNC_SHIFT,
+} from './constants'
+
+/**
+ * FR-Type Instruction
+ */
+export default class FRInstruction implements Instruction {
+  public type: string = 'FR'
+  public op: number
+  public fmt: number
+  public ft: number
+  public fs: number
+  public fd: number
+  public func: number
+
+  constructor(op: number, fmt: number, ft: number, fs: number, fd: number, func: number) {
+    this.op = op
+    this.fmt = fmt
+    this.ft = ft
+    this.fs = fs
+    this.fd = fd
+    this.func = func
+  }
+
+  public toInt(): number {
+    const { op, fmt, ft, fs, fd, func } = this
+    return (op << OP_SHIFT) + (fmt << FMT_SHIFT) + (ft << FT_SHIFT) + (fs << FS_SHIFT) + (fd << FD_SHIFT) + func
+  }
+}

--- a/src/Instruction/constants.ts
+++ b/src/Instruction/constants.ts
@@ -17,3 +17,15 @@ export const SH_SHIFT   = RD_SHIFT - 5
 export const FUNC_SHIFT = SH_SHIFT - 6
 export const IMM_SHIFT  = RT_SHIFT - 16
 export const ADDR_SHIFT = OP_SHIFT - 26
+
+// Floating-point masks
+export const FMT_MASK = 0x03e00000
+export const FT_MASK  = 0x001f0000
+export const FS_MASK  = 0x0000f800
+export const FD_MASK  = 0x000007c0
+
+// Floating-point shifts
+export const FMT_SHIFT = OP_SHIFT  - 5
+export const FT_SHIFT  = FMT_SHIFT - 5
+export const FS_SHIFT  = FT_SHIFT  - 5
+export const FD_SHIFT  = FS_SHIFT  - 5

--- a/src/Instruction/utils.ts
+++ b/src/Instruction/utils.ts
@@ -2,6 +2,8 @@ import Instruction from './Instruction'
 import RInstruction from './RInstruction'
 import JInstruction from './JInstruction'
 import IInstruction from './IInstruction'
+import FIInstruction from './FIInstruction'
+import FRInstruction from './FRInstruction'
 
 import {
   OP_MASK,
@@ -20,6 +22,14 @@ import {
   IMM_SHIFT,
   ADDR_MASK,
   ADDR_SHIFT,
+  FMT_MASK,
+  FMT_SHIFT,
+  FT_MASK,
+  FT_SHIFT,
+  FD_MASK,
+  FD_SHIFT,
+  FS_MASK,
+  FS_SHIFT,
 } from './constants'
 
 export default {
@@ -39,6 +49,23 @@ export default {
       const addr = (instr & ADDR_MASK) >>> ADDR_SHIFT
       return new JInstruction(op, addr)
     }
+    if (op === 0x11) {
+      // FR or FI type
+      const fmt = (instr & FMT_MASK) >>> FMT_SHIFT
+      const ft  = (instr & FT_MASK)  >>> FT_SHIFT
+
+      if (fmt === 0x8) {
+        const imm = (instr & IMM_MASK) >>> IMM_SHIFT;
+        return new FIInstruction(op, fmt, ft, imm)
+      }
+
+      const fs = (instr & FS_MASK) >>> FS_SHIFT
+      const fd = (instr & FD_MASK) >>> FD_SHIFT
+      const func = (instr & FUNC_MASK) >>> FUNC_SHIFT
+
+      return new FRInstruction(op, fmt, ft, fs, fd, func)
+
+    }
 
     const rs = (instr & RS_MASK) >>> RS_SHIFT
     const rt = (instr & RT_MASK) >>> RT_SHIFT
@@ -57,5 +84,13 @@ export default {
 
   isJ(instr: Instruction): instr is JInstruction {
     return instr.type === 'J'
+  },
+
+  isFR(instr: Instruction): instr is FRInstruction {
+    return instr.type === 'FR'
+  },
+
+  isFI(instr: Instruction): instr is FIInstruction {
+    return instr.type === 'FI'
   },
 }

--- a/test/Instruction/index.test.ts
+++ b/test/Instruction/index.test.ts
@@ -2,68 +2,112 @@ import Instruction, { IInstruction, JInstruction, RInstruction, utils } from '..
 import { expect } from 'chai'
 
 describe('Instruction', () => {
-  let instr: any;
+  let instr: any
 
   describe('Type R instruction', () => {
     before('Creates instruction', () => {
       // 0b00000001010010110100100000100000
-      instr = utils.fromInt(0x014b4820);
-      console.log('Instruction: ', instr);
+      instr = utils.fromInt(0x014b4820)
+      console.log('Instruction: ', instr)
     })
 
     it('Instruction created is of the right type', () => {
-      expect(utils.isR(instr)).to.be.true;
-      expect(instr.type).to.equal('R');
+      expect(utils.isR(instr)).to.be.true
+      expect(instr.type).to.equal('R')
     })
 
-    it('Verifies opcode, rs, rt, rd, shamt, funct', () => {
+    it('Verifies opcode, rs, rt, rd, shamt and funct', () => {
       // 0b000000 01010 01011 01001 00000 100000
-      expect(instr.op).to.equal(0b000000);
-      expect(instr.rs).to.equal(0b01010);
-      expect(instr.rt).to.equal(0b01011);
-      expect(instr.rd).to.equal(0b01001);
-      expect(instr.sh).to.equal(0b00000);
-      expect(instr.func).to.equal(0x20);
+      expect(instr.op).to.equal(0b000000)
+      expect(instr.rs).to.equal(0b01010)
+      expect(instr.rt).to.equal(0b01011)
+      expect(instr.rd).to.equal(0b01001)
+      expect(instr.sh).to.equal(0b00000)
+      expect(instr.func).to.equal(0x20)
     })
   })
 
   describe('Type I instruction', () => {
     before('Creates instruction', () => {
       // 0b00100100000000101111111111111111
-      instr = utils.fromInt(0x2402ffff);
-      console.log('Instruction: ', instr);
+      instr = utils.fromInt(0x2402ffff)
+      console.log('Instruction: ', instr)
     })
 
     it('Instruction created is of the right type', () => {
-      expect(utils.isI(instr)).to.be.true;
-      expect(instr.type).to.equal('I');
+      expect(utils.isI(instr)).to.be.true
+      expect(instr.type).to.equal('I')
     })
 
     it('Verifies opcode, rs, rt and immediate', () => {
       // 0b001001 00000 00010 1111111111111111
-      expect(instr.op).to.equal(0b001001);
-      expect(instr.rs).to.equal(0b00000);
-      expect(instr.rt).to.equal(0b00010);
-      expect(instr.imm).to.equal(0xffff);
+      expect(instr.op).to.equal(0b001001)
+      expect(instr.rs).to.equal(0b00000)
+      expect(instr.rt).to.equal(0b00010)
+      expect(instr.imm).to.equal(0xffff)
     })
   })
 
   describe('Type J instruction', () => {
     before('Creates instruction', () => {
       // 0b00001000001011111111111111111111
-      instr = utils.fromInt(0x082fffff);
-      console.log('Instruction: ', instr);
+      instr = utils.fromInt(0x082fffff)
+      console.log('Instruction: ', instr)
     })
 
     it('Instruction created is of the right type', () => {
-      expect(utils.isJ(instr)).to.be.true;
-      expect(instr.type).to.equal('J');
+      expect(utils.isJ(instr)).to.be.true
+      expect(instr.type).to.equal('J')
     })
 
     it('Verifies opcode and address', () => {
       // 0b000010 00 0010 1111 1111 1111 1111 1111
-      expect(instr.j).to.equal(0b000010);
-      expect(instr.addr).to.equal(0x02fffff);
+      expect(instr.j).to.equal(0b000010)
+      expect(instr.addr).to.equal(0x02fffff)
+    })
+  })
+
+  describe('Type FR instruction', () => {
+    before('Creates instruction', () => {
+      // 0b0100 0110 0000 0100 0010 1001 1000 0000
+      instr = utils.fromInt(0x46042980)
+      console.log('Instruction: ', instr)
+    })
+
+    it('Instruction created is of the right type', () => {
+      expect(utils.isFR(instr)).to.be.true
+      expect(instr.type).to.equal('FR')
+    })
+
+    it('Verifies opcode, fmt, ft, fs, fd and funct', () => {
+      // 0b010001 10000 00100 00101 00110 000000
+      expect(instr.op).to.equal(0x11)
+      expect(instr.fmt).to.equal(0x10)
+      expect(instr.ft).to.equal(0b00100)
+      expect(instr.fs).to.equal(0b00101)
+      expect(instr.fd).to.equal(0b00110)
+      expect(instr.func).to.equal(0x0)
+    })
+  })
+
+  describe('Type FI instruction', () => {
+    before('Creates instruction', () => {
+      // 0b010001 01000 00001 1111111111111111
+      instr = utils.fromInt(0x4501ffff)
+      console.log('Instruction: ', instr)
+    })
+
+    it('Instruction created is of the right type', () => {
+      expect(utils.isFI(instr)).to.be.true
+      expect(instr.type).to.equal('FI')
+    })
+
+    it('Verifies opcode, rs, rt and immediate', () => {
+      // 0b010001 01000 00001 1111111111111111
+      expect(instr.op).to.equal(0x11)
+      expect(instr.fmt).to.equal(0x8)
+      expect(instr.ft).to.equal(0x1)
+      expect(instr.imm).to.equal(0xffff)
     })
   })
 })

--- a/test/Instruction/index.test.ts
+++ b/test/Instruction/index.test.ts
@@ -1,8 +1,69 @@
-import Instruction, { utils } from '../../src/Instruction'
+import Instruction, { IInstruction, JInstruction, RInstruction, utils } from '../../src/Instruction'
+import { expect } from 'chai'
 
 describe('Instruction', () => {
-  it('works', () => {
-    const instr = utils.fromInt(0x2402ffff)
-    console.log('Instruction: ', instr)
+  let instr: any;
+
+  describe('Type R instruction', () => {
+    before('Creates instruction', () => {
+      // 0b00000001010010110100100000100000
+      instr = utils.fromInt(0x014b4820);
+      console.log('Instruction: ', instr);
+    })
+
+    it('Instruction created is of the right type', () => {
+      expect(utils.isR(instr)).to.be.true;
+      expect(instr.type).to.equal('R');
+    })
+
+    it('Verifies opcode, rs, rt, rd, shamt, funct', () => {
+      // 0b000000 01010 01011 01001 00000 100000
+      expect(instr.op).to.equal(0b000000);
+      expect(instr.rs).to.equal(0b01010);
+      expect(instr.rt).to.equal(0b01011);
+      expect(instr.rd).to.equal(0b01001);
+      expect(instr.sh).to.equal(0b00000);
+      expect(instr.func).to.equal(0x20);
+    })
+  })
+
+  describe('Type I instruction', () => {
+    before('Creates instruction', () => {
+      // 0b00100100000000101111111111111111
+      instr = utils.fromInt(0x2402ffff);
+      console.log('Instruction: ', instr);
+    })
+
+    it('Instruction created is of the right type', () => {
+      expect(utils.isI(instr)).to.be.true;
+      expect(instr.type).to.equal('I');
+    })
+
+    it('Verifies opcode, rs, rt and immediate', () => {
+      // 0b001001 00000 00010 1111111111111111
+      expect(instr.op).to.equal(0b001001);
+      expect(instr.rs).to.equal(0b00000);
+      expect(instr.rt).to.equal(0b00010);
+      expect(instr.imm).to.equal(0xffff);
+    })
+  })
+
+  describe('Type J instruction', () => {
+    before('Creates instruction', () => {
+      // 0b00001000001011111111111111111111
+      instr = utils.fromInt(0x082fffff);
+      console.log('Instruction: ', instr);
+    })
+
+    it('Instruction created is of the right type', () => {
+      expect(utils.isJ(instr)).to.be.true;
+      expect(instr.type).to.equal('J');
+    })
+
+    it('Verifies opcode and address', () => {
+      // 0b000010 00 0010 1111 1111 1111 1111 1111
+      expect(instr.j).to.equal(0b000010);
+      expect(instr.addr).to.equal(0x02fffff);
+    })
   })
 })


### PR DESCRIPTION
This pull request adds more tests to the structure of instructions as a whole along with new types of instructions, FR and FI.

Based on [this sheet](https://inst.eecs.berkeley.edu/~cs61c/resources/MIPS_Green_Sheet.pdf) used in my class about assembly language.